### PR TITLE
Add a user model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ documentation.
 Development
 -----------
 
+To run the tests::
+
+    $ nosetests
+
 To lint your code automatically when you make changes::
 
     $ cp tube.py.sample tube.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 demands==1.0.6
 flake8==2.4.1
+funcsigs==0.4
+mock==1.1.0
 nose==1.3.4
 pep257==0.6.0
+pinocchio==0.4.2
 sphinx-rtd-theme==0.1.8
 testtube==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ exclude = docs
 [pep257]
 ignore = D100,D203
 match-dir = yolapy
+
+[nosetests]
+with-spec=1
+spec-color=1

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -20,62 +20,20 @@ class TestUserClient(UserTestCase):
         self.assertEqual(User().client, self.client)
 
 
-class TestUserEmail(UserTestCase):
-
-    def setUp(self):
-        super(TestUserEmail, self).setUp()
-        self.user = User(email='me@example.com')
-
-    def test_is_set_as_a_preference(self):
-        self.assertEqual(self.user.preferences['wl_email'], 'me@example.com')
-
-    def test_is_not_destroyed_when_saving(self):
-        self.client.create_user.return_value = {
-            'email': 'legacy-1234567890asdf1234567890asdf.com'
-        }
-        self.user.save()
-        self.assertEqual(self.user.email, 'me@example.com')
-
-
-class TestUserLegacyEmail(UserTestCase):
-
-    def setUp(self):
-        super(TestUserLegacyEmail, self).setUp()
-        self.user = User(name='Jo', surname='Jo', email='me@example.com')
-        self.user._legacy_email = 'legacy-1234567890asdf1234567890asdf.com'
-
-    def test_is_used_when_saving(self):
-        self.user.save()
-        save_call = self.client.create_user.call_args[1]
-        self.assertEqual(save_call, {
-            'name': 'Jo',
-            'surname': 'Jo',
-            'partner_id': 'WL_DEFAULT',
-            'email': 'legacy-1234567890asdf1234567890asdf.com',
-            'preferences': {'wl_email': 'me@example.com'},
-        })
-
-
 class TestUserSave(UserTestCase):
 
     def test_uses_service_to_create_a_new_user(self):
         user_attrs = {
             'name': 'First',
             'surname': 'Name',
-            'email': 'legacy-abc123@example.com',
+            'email': 'email@example.com',
             'partner_id': 'WL_PARTNER',
-            'preferences': {'locale': 'en', 'wl_email': 'email@example.com'},
+            'preferences': {'locale': 'en'},
         }
         user = User(**user_attrs)
-        user._legacy_email = 'legacy-abc123@example.com'
         user.save()
         create_user_call = self.client.create_user.call_args[1]
         self.assertEqual(user_attrs, create_user_call)
-
-    def test_generates_a_legacy_email(self):
-        User().save()
-        create_user_call = self.client.create_user.call_args[1]
-        self.assertTrue(create_user_call['email'] is not None)
 
 
 class TestUserPartnerId(UserTestCase):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+from mock import patch
+
+from yolapy.models.user import User
+
+
+class UserTestCase(TestCase):
+
+    def setUp(self):
+        self.client_patcher = patch('yolapy.models.user.Yola')
+        self.addCleanup(self.client_patcher.stop)
+        self.client = self.client_patcher.start().return_value
+        self.client.username = 'WL_DEFAULT'
+
+
+class TestUserClient(UserTestCase):
+
+    def test_is_a_yola_client(self):
+        self.assertEqual(User().client, self.client)
+
+
+class TestUserSave(UserTestCase):
+
+    def test_uses_service_to_create_a_new_user(self):
+        user_attrs = {
+            'name': 'First',
+            'surname': 'Name',
+            'email': 'email@example.com',
+            'partner_id': 'WL_PARTNER',
+            'preferences': {'locale': 'en'},
+        }
+        user = User(**user_attrs)
+        user.save()
+        create_user_call = self.client.create_user.call_args[1]
+        self.assertEqual(user_attrs, create_user_call)
+
+
+class TestUserPartnerId(UserTestCase):
+
+    def test_uses_client_config_as_default_partner_id(self):
+        self.assertEqual(User().partner_id, 'WL_DEFAULT')
+
+    def test_can_be_set_via_init(self):
+        self.assertEqual(User(partner_id='WL_DOG').partner_id, 'WL_DOG')
+
+    def test_can_be_set_via_attribute(self):
+        user = User()
+        user.partner_id = 'WL_CAT'
+        self.assertEqual(user.partner_id, 'WL_CAT')
+
+
+class TestUserUpdate(UserTestCase):
+
+    def test_updates_all_attributes_passed_in(self):
+        user_attrs = {'name': 'Nameski', 'email': 'emailz@example.com'}
+        u = User()
+        u.update(**user_attrs)
+        self.assertEqual(u.name, 'Nameski')
+        self.assertEqual(u.email, 'emailz@example.com')

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -20,20 +20,62 @@ class TestUserClient(UserTestCase):
         self.assertEqual(User().client, self.client)
 
 
+class TestUserEmail(UserTestCase):
+
+    def setUp(self):
+        super(TestUserEmail, self).setUp()
+        self.user = User(email='me@example.com')
+
+    def test_is_set_as_a_preference(self):
+        self.assertEqual(self.user.preferences['wl_email'], 'me@example.com')
+
+    def test_is_not_destroyed_when_saving(self):
+        self.client.create_user.return_value = {
+            'email': 'legacy-1234567890asdf1234567890asdf.com'
+        }
+        self.user.save()
+        self.assertEqual(self.user.email, 'me@example.com')
+
+
+class TestUserLegacyEmail(UserTestCase):
+
+    def setUp(self):
+        super(TestUserLegacyEmail, self).setUp()
+        self.user = User(name='Jo', surname='Jo', email='me@example.com')
+        self.user._legacy_email = 'legacy-1234567890asdf1234567890asdf.com'
+
+    def test_is_used_when_saving(self):
+        self.user.save()
+        save_call = self.client.create_user.call_args[1]
+        self.assertEqual(save_call, {
+            'name': 'Jo',
+            'surname': 'Jo',
+            'partner_id': 'WL_DEFAULT',
+            'email': 'legacy-1234567890asdf1234567890asdf.com',
+            'preferences': {'wl_email': 'me@example.com'},
+        })
+
+
 class TestUserSave(UserTestCase):
 
     def test_uses_service_to_create_a_new_user(self):
         user_attrs = {
             'name': 'First',
             'surname': 'Name',
-            'email': 'email@example.com',
+            'email': 'legacy-abc123@example.com',
             'partner_id': 'WL_PARTNER',
-            'preferences': {'locale': 'en'},
+            'preferences': {'locale': 'en', 'wl_email': 'email@example.com'},
         }
         user = User(**user_attrs)
+        user._legacy_email = 'legacy-abc123@example.com'
         user.save()
         create_user_call = self.client.create_user.call_args[1]
         self.assertEqual(user_attrs, create_user_call)
+
+    def test_generates_a_legacy_email(self):
+        User().save()
+        create_user_call = self.client.create_user.call_args[1]
+        self.assertTrue(create_user_call['email'] is not None)
 
 
 class TestUserPartnerId(UserTestCase):

--- a/tube.py.sample
+++ b/tube.py.sample
@@ -5,19 +5,20 @@ Automatically run tests when files change by running: stir
 See: https://github.com/thomasw/testtube
 """
 
-from testtube.helpers import Helper, Flake8, Pep257
+from testtube.helpers import Flake8, Helper, Nosetests, Pep257
 
 
-class Clear(Helper):
-    """Clear the screen."""
-
+class ScreenClearer(Helper):
     command = 'clear'
 
+    def success(self, *args):
+        pass
 
-clear = Clear(all_files=True)
+clear = ScreenClearer(all_files=True)
 lint = Flake8(all_files=True)
-docstrings = Pep257(all_files=True)
+lint_docs = Pep257(all_files=True)
+test = Nosetests()
 
 PATTERNS = (
-    (r'.*\.py$', [clear, lint, docstrings], {'fail_fast': True}),
+    (r'.*\.py$', [clear, lint, test, lint_docs], {'fail_fast': True}),
 )

--- a/yolapy/models/__init__.py
+++ b/yolapy/models/__init__.py
@@ -1,0 +1,1 @@
+from yolapy.models.user import User  # noqa

--- a/yolapy/models/user.py
+++ b/yolapy/models/user.py
@@ -1,0 +1,79 @@
+from yolapy.services import Yola
+
+
+class User(object):
+
+    """Yola User - a service model that uses the yola client for persistence.
+
+    Example use:
+    ```
+    from yolapy.models import User as YolaUser
+
+    yola_user = YolaUser(
+        email='test@example.com',
+        name='Jane',
+        surname='Doe',
+        partner_id='WL_PARTNER',
+        preferences={'locale': 'en'})
+
+    yola_user.save()
+    ```
+    """
+
+    def __init__(self, active=False, deleted=None, email=None, id=None,
+                 name=None, partner_id=None, preferences=None,
+                 signup_date=None, surname=None):
+        """Construct a Yola User.
+
+        The data in a User instance does not persist until it has been saved.
+
+
+        :param active: Bool, toggled ``False`` when user is deactivated
+        :param deleted: Timestamp, date the user was deleted
+        :param email: Str, user's email address
+        :param id: Str, user's 32 character ID
+        :param name: Str, user's first name
+        :param partner_id: Str, yola partner responsible the user
+        :param preferences: Dict, user's preferences
+        :param signup_date: Timestamp, date the user signed up
+        :param surname: Str, user's second name
+
+        :return: :class:`User <User>` object
+        :rtype: yolapy.users.models.User
+
+        """
+        self.client = Yola()
+
+        self.partner_id = partner_id or self.client.username
+        self.active = active
+        self.deleted = deleted
+        self.email = email
+        self.id = id
+        self.name = name
+        self.preferences = preferences or {}
+        self.signup_date = signup_date
+        self.surname = surname
+
+    def _save_create(self):
+        user = self.client.create_user(
+            email=self.email,
+            name=self.name,
+            partner_id=self.partner_id,
+            preferences=self.preferences,
+            surname=self.surname)
+        self.update(**user)
+
+    def _save_update(self):
+        raise NotImplementedError()
+
+    def save(self):
+        """POST the user data back to the service."""
+        if self.id:
+            self._save_update()
+        else:
+            self._save_create()
+
+    def update(self, **attributes):
+        """Update all keyword arguments to update instance attributes."""
+        for attr, val in attributes.items():
+            setattr(self, attr, val)

--- a/yolapy/models/user.py
+++ b/yolapy/models/user.py
@@ -1,5 +1,3 @@
-import uuid
-
 from yolapy.services import Yola
 
 
@@ -49,38 +47,20 @@ class User(object):
         self.partner_id = partner_id or self.client.username
         self.active = active
         self.deleted = deleted
+        self.email = email
         self.id = id
         self.name = name
         self.preferences = preferences or {}
         self.signup_date = signup_date
         self.surname = surname
 
-        self._legacy_email = None
-        if email:
-            self.email = email
-
-    @property
-    def email(self):
-        """Store email in preferences, sidestepping a legacy constraint."""
-        return self.preferences.get('wl_email')
-
-    @email.setter
-    def email(self, email):
-        self.preferences['wl_email'] = email
-
-    def _get_or_create_legacy_email(self):
-        if not self._legacy_email:
-            self._legacy_email = '%s@yola.net' % uuid.uuid4().hex
-        return self._legacy_email
-
     def _save_create(self):
         user = self.client.create_user(
-            email=self._get_or_create_legacy_email(),
+            email=self.email,
             name=self.name,
             partner_id=self.partner_id,
             preferences=self.preferences,
             surname=self.surname)
-        user['_legacy_email'] = user.pop('email')
         self.update(**user)
 
     def _save_update(self):

--- a/yolapy/services.py
+++ b/yolapy/services.py
@@ -43,4 +43,5 @@ class Yola(
         config.update(kwargs)
         assert(config['url'])
         assert(config['auth'])
+        self.username = config['auth'][0]
         super(Yola, self).__init__(**config)


### PR DESCRIPTION
The user model uses the yola client for persistence.

With this change, can expect a provisioning procedure to look like:

``` python
from yolapy import User as YolaUser

def provision(user):
    yola_user = YolaUser(name=user.name, surname='', email=user.email)
    yola_user.save()
    user.yola_id = yola_user.id
```
