### PR TITLE
Return values from change_type and activate_trial methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+0.1.5 (2015-11-23)
+------------------
+
+* Return values from `change_subscription_type` and `activate_trial_subscription`
+  methods.
+* Fixed failing integration tests.
+
+
 0.1.4 (2015-11-19)
 ------------------
 

--- a/tests/test_integration/test_settings.py.sample
+++ b/tests/test_integration/test_settings.py.sample
@@ -1,2 +1,2 @@
-url = 'https://wl-test.example.com/'
+url = 'https://wl.<test>.env.yola.net/'
 auth = ('username', 'password')

--- a/tests/test_integration/test_subscription_resource.py
+++ b/tests/test_integration/test_subscription_resource.py
@@ -42,8 +42,8 @@ class TestYolaSubscription(YolaServiceTestCase):
 
     def test_can_activate_a_trial_subscription(self):
         user = create_user(self.service, partner_id=self.partner['id'])
-        sub = self.service.create_subscription('wl_basic', user['id'], {
-              'trial': True})
+        sub = self.service.create_subscription(
+            'wl_basic', user['id'], {'trial': True})
         self.assertTrue(sub['properties']['trial'])
 
         activated_sub = self.service.activate_trial_subscription(sub['id'])
@@ -51,8 +51,8 @@ class TestYolaSubscription(YolaServiceTestCase):
 
     def test_can_change_subscription_type(self):
         user = create_user(self.service, partner_id=self.partner['id'])
-        sub = self.service.create_subscription('wl_basic', user['id'], {
-              'trial': True})
+        sub = self.service.create_subscription(
+            'wl_basic', user['id'], {'trial': True})
         self.assertEqual(sub['type'], 'wl_basic')
 
         modified_sub = self.service.change_subscription_type(

--- a/tests/test_integration/test_subscription_resource.py
+++ b/tests/test_integration/test_subscription_resource.py
@@ -39,3 +39,22 @@ class TestYolaSubscription(YolaServiceTestCase):
         self.service.reactivate_subscription(cancelled_sub['id'], 'testing')
         reactivated_sub = self.service.get_subscription(cancelled_sub['id'])
         self.assertEqual(reactivated_sub['status'], 'active')
+
+    def test_can_activate_a_trial_subscription(self):
+        user = create_user(self.service, partner_id=self.partner['id'])
+        sub = self.service.create_subscription('wl_basic', user['id'], {
+              'trial': True})
+        self.assertTrue(sub['properties']['trial'])
+
+        activated_sub = self.service.activate_trial_subscription(sub['id'])
+        self.assertFalse(activated_sub['properties'].get('trial'))
+
+    def test_can_change_subscription_type(self):
+        user = create_user(self.service, partner_id=self.partner['id'])
+        sub = self.service.create_subscription('wl_basic', user['id'], {
+              'trial': True})
+        self.assertEqual(sub['type'], 'wl_basic')
+
+        modified_sub = self.service.change_subscription_type(
+            sub['id'], 'wl_lite')
+        self.assertEqual(modified_sub['type'], 'wl_lite')

--- a/yolapy/__init__.py
+++ b/yolapy/__init__.py
@@ -1,4 +1,4 @@
 # setup.py needs to import this without worrying about required packages being
 # installed. So if you add imports here, you may need to do something like:
 # https://github.com/mitsuhiko/click/blob/da080dd2de1a116fc5789ffdc1ec6ffb864f2044/setup.py#L1-L11
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/yolapy/resources/subscription.py
+++ b/yolapy/resources/subscription.py
@@ -46,16 +46,16 @@ class SubscriptionResourceMixin(object):
 
         >>> yola.cancel_subscription('subscription_id', 'some reason')
         """
-        self.post(self._subscription_path(subscription_id, 'cancel'),
-                  data={'reason': reason})
+        return self.post(self._subscription_path(subscription_id, 'cancel'),
+                  data={'reason': reason}).json()
 
     def reactivate_subscription(self, subscription_id, reason):
         """Re-activate a cancelled subscription.
 
         >>> yola.reactivate_subscription('subscription_id', 'some reason')
         """
-        self.post(self._subscription_path(subscription_id, 'reactivate'),
-                  data={'reason': reason})
+        return self.post(self._subscription_path(subscription_id, 'reactivate'),
+                  data={'reason': reason}).json()
 
     def activate_trial_subscription(self, subscription_id):
         """Convert trial subscription to active.

--- a/yolapy/resources/subscription.py
+++ b/yolapy/resources/subscription.py
@@ -46,16 +46,18 @@ class SubscriptionResourceMixin(object):
 
         >>> yola.cancel_subscription('subscription_id', 'some reason')
         """
-        return self.post(self._subscription_path(subscription_id, 'cancel'),
-                  data={'reason': reason}).json()
+        return self.post(
+            self._subscription_path(subscription_id, 'cancel'),
+            data={'reason': reason}).json()
 
     def reactivate_subscription(self, subscription_id, reason):
         """Re-activate a cancelled subscription.
 
         >>> yola.reactivate_subscription('subscription_id', 'some reason')
         """
-        return self.post(self._subscription_path(subscription_id, 'reactivate'),
-                  data={'reason': reason}).json()
+        return self.post(
+            self._subscription_path(subscription_id, 'reactivate'),
+            data={'reason': reason}).json()
 
     def activate_trial_subscription(self, subscription_id):
         """Convert trial subscription to active.

--- a/yolapy/resources/subscription.py
+++ b/yolapy/resources/subscription.py
@@ -37,8 +37,9 @@ class SubscriptionResourceMixin(object):
 
         See https://wl.qa.yola.net/subscriptions/ for available types.
         """
-        self.post(self._subscription_path(subscription_id, 'change_type'),
-                  data={'new_type': new_type})
+        return self.post(
+            self._subscription_path(subscription_id, 'change_type'),
+            data={'new_type': new_type}).json()
 
     def cancel_subscription(self, subscription_id, reason):
         """Cancel active subscription.
@@ -61,7 +62,8 @@ class SubscriptionResourceMixin(object):
 
         >>> yola.activate_trial_subscription('subscription_id')
         """
-        self.post(self._subscription_path(subscription_id, 'remove_trial'))
+        return self.post(
+            self._subscription_path(subscription_id, 'remove_trial')).json()
 
     def create_subscription(self, subscription_type, user_id, properties):
         """Create a new subscription.


### PR DESCRIPTION
- Return values from `change_subscription_type` and `activate_trial_subscription`
  methods.
- Fixed failing integration tests.
  #21 

**Why?**

When subscription is activated (`trial` is removed), Michango actually creates new subscription, which has another ID. So the tests were wrong, because they were relying on old subscription ID. Same about changing subscription type. 

As a bonus, changed WL host example in a config sample. Old one was not obvious.

Ping @blaix @RayeN 
