### PR TITLE
Remove suspend/resume user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+DEV
+----
+
+* **Breaking change:** Remove `Yola.suspend_user` and `Yola.resume_user`.
+
 0.1.7 (2015-12-02)
 ------------------
 

--- a/tests/test_integration/test_user_resource.py
+++ b/tests/test_integration/test_user_resource.py
@@ -45,17 +45,6 @@ class TestYolaUser(YolaServiceTestCase):
         with self.assertRaises(demands.HTTPServiceError):
             self.service.get_user(user['id'])
 
-    def test_suspend_and_resume_user(self):
-        self.assertTrue(self.user['active'])
-
-        self.service.suspend_user(self.user_id)
-        user = self.service.get_user(self.user_id)
-        self.assertFalse(user['active'])
-
-        self.service.resume_user(self.user_id)
-        user = self.service.get_user(self.user_id)
-        self.assertTrue(user['active'])
-
     def test_get_sso_create_site_url(self):
         url = self.service.get_sso_create_site_url(self.user_id, 'example.com')
         self.assertTrue(url.startswith('http'))

--- a/yolapy/resources/user.py
+++ b/yolapy/resources/user.py
@@ -65,20 +65,6 @@ class UserResourceMixin(object):
         """
         self.delete(self._user_path(user_id))
 
-    def suspend_user(self, user_id):
-        """Suspend a user.
-
-        >>> yola.suspend_user('user_id')
-        """
-        self.post(self._user_path(user_id, 'suspend'))
-
-    def resume_user(self, user_id):
-        """Resume a user.
-
-        >>> yola.resume_user('user_id')
-        """
-        self.post(self._user_path(user_id, 'resume'))
-
     def get_sso_create_site_url(self, user_id, domain):
         """Get SSO create site url for a particular user and domain.
 


### PR DESCRIPTION
We no longer let partners do this functionality through the Yola API. The methods now result in auth errors.
