### PR TITLE
add a User.get classmethod that returns an instantiated User object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Dev
 ----
 
 * Handle pagination in Site.list
+* Add ``User.get`` class method that returns a populated User object
 
 0.2.2 (2016-04-06)
 ------------------

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -20,6 +20,37 @@ class TestUserClient(UserTestCase):
         self.assertEqual(User().client, self.client)
 
 
+class TestUserGet(UserTestCase):
+    """User.get"""
+
+    def test_instantiates_user_with_attrs_from_service(self):
+        self.client.get_user.return_value = {
+            'id': '123',
+            'name': 'Firstname',
+            'surname': 'Lastname',
+            'email': 'email@example.com',
+            'active': True,
+            'signupDate': '2016-01-01',
+            'deleted': '2016-02-01',
+            'partner_id': 'PARTNER',
+            'preferences': {'currency': 'USD'},
+        }
+
+        user = User.get('123')
+
+        self.client.get_user.assert_called_once_with('123')
+        self.assertEqual(user.id, '123')
+        self.assertEqual(user.active, True)
+        self.assertEqual(user.deleted, '2016-02-01')
+        self.assertEqual(user.signup_date, '2016-01-01')
+        self.assertEqual(user.partner_id, 'PARTNER')
+        self.assertEqual(user.name, 'Firstname')
+        self.assertEqual(user.surname, 'Lastname')
+        self.assertEqual(user.email, 'email@example.com')
+        self.assertEqual(user.name, 'Firstname')
+        self.assertDictEqual(user.preferences, {'currency': 'USD'})
+
+
 class TestUserSave(UserTestCase):
 
     def test_uses_service_to_create_a_new_user(self):

--- a/yolapy/models/user.py
+++ b/yolapy/models/user.py
@@ -54,6 +54,13 @@ class User(object):
         self.signup_date = signup_date
         self.surname = surname
 
+    @classmethod
+    def get(cls, user_id):
+        """Get a user from the Yola API."""
+        user_attributes = Yola().get_user(user_id)
+        user_attributes['signup_date'] = user_attributes.pop('signupDate')
+        return cls(**user_attributes)
+
     def _save_create(self):
         user = self.client.create_user(
             email=self.email,


### PR DESCRIPTION
Having to populate a User object with the data returned from `Yola().get_user()` is annoying, especially since the service returns `signupDate` and the model expects that attribute to be named `signup_date`.

Let's use this new `User.get()` method so we never have to deal with that again.
