### PR TITLE
update version of demands specified in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     install_requires=[
-        'demands >= 1.1.0, < 2.0.0',
+        'demands >= 2.0.0, < 2.1.0',
         'six >= 1.9.0, < 1.10.0',
     ],
     tests_require=[


### PR DESCRIPTION
The demands version was bumped to 2.0.0 in https://github.com/yola/yolapy/pull/50 in requirements.txt but was not updated in setup.py.

Now requirements.txt and setup.py match.
