### PR TITLE
bump version to 0.2.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+0.2.4 (2016-06-17)
+------------------
+* Fix mismatch between demands version in setup.py and requirements.txt
+
 0.2.3 (2016-06-17)
 ------------------
 

--- a/yolapy/__init__.py
+++ b/yolapy/__init__.py
@@ -1,4 +1,4 @@
 # setup.py needs to import this without worrying about required packages being
 # installed. So if you add imports here, you may need to do something like:
 # https://github.com/mitsuhiko/click/blob/da080dd2de1a116fc5789ffdc1ec6ffb864f2044/setup.py#L1-L11
-__version__ = '0.2.3'
+__version__ = '0.2.4'


### PR DESCRIPTION
0.2.4 fixes the mismatch between demands version in setup.py and requirements.txt
