### PR TITLE
Add site import model and resources to Yola api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ DEV
 ------------------
 * Remove `Yola.subscribe_to_campaign()` and `Yola.cancel_campaign_subscription`
   methods, they aren't allowed to be used externally.
+* Add SiteImport model and api for creation and listing
 
 
 0.4.2

--- a/tests/models/test_siteimport.py
+++ b/tests/models/test_siteimport.py
@@ -1,0 +1,62 @@
+import unittest
+
+from mock import patch
+
+from yolapy.models import siteimport
+
+
+class SiteImportTestCase(unittest.TestCase):
+    def setUp(self):
+        patcher = patch.object(siteimport, 'Yola')
+        self.yola = patcher.start().return_value
+        self.addCleanup(patcher.stop)
+
+
+class SiteImportCreate(SiteImportTestCase):
+    """SiteImport.create"""
+    def setUp(self):
+        super(SiteImportCreate, self).setUp()
+        self.url = 'url'
+        self.user_id = 'user_id'
+        self.siteimport = siteimport.SiteImport.create(self.url, self.user_id)
+
+    def test_creates_site_import_with_passed_arguments(self):
+        self.yola.create_site_import.assert_called_once_with(
+            self.url, self.user_id)
+
+    def test_returns_site_import_instance(self):
+        self.assertIsInstance(self.siteimport, siteimport.SiteImport)
+
+
+class SiteImportGet(SiteImportTestCase):
+    def setUp(self):
+        super(SiteImportGet, self).setUp()
+        self.id = 'id'
+        self.site_import_data = {'id': self.id}
+        self.yola.get_site_import.return_value = self.site_import_data
+        self.site_import = siteimport.SiteImport.get(self.id)
+
+    def test_gets_specified_site_import(self):
+        self.yola.get_site_import.assert_called_once_with(self.id)
+
+    def test_returns_site_import_instance(self):
+        self.assertIsInstance(self.site_import, siteimport.SiteImport)
+
+
+class SiteImportList(SiteImportTestCase):
+    def setUp(self):
+        super(SiteImportList, self).setUp()
+        self.site_imports_data = [{'id': 1}, {'id': 2}]
+        self.yola.list_site_imports.return_value = {
+            'results': self.site_imports_data}
+        self.filters = {'one': 1, 'two': 2}
+        self.site_imports = siteimport.SiteImport.list(**self.filters)
+
+    def test_gets_specified_site_import_list(self):
+        _, kwargs = self.yola.list_site_imports.call_args
+        for filter, value in self.filters.items():
+            self.assertEqual(kwargs[filter], value)
+
+    def test_returns_site_import_list(self):
+        for site_import in self.site_imports:
+            self.assertIsInstance(site_import, siteimport.SiteImport)

--- a/tests/test_integration/test_siteimport_resource.py
+++ b/tests/test_integration/test_siteimport_resource.py
@@ -1,0 +1,28 @@
+from tests.test_integration.helpers import (
+    create_user_with_subscription)
+from tests.test_integration.test_case import YolaServiceTestCase
+
+
+class TestYolaSiteImport(YolaServiceTestCase):
+    """Yola: Site Import resource"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestYolaSiteImport, cls).setUpClass()
+        cls.user = create_user_with_subscription(
+            cls.service, **{'name': 'Kendrick Lamar'})
+        cls.site_import = cls.service.create_site_import(
+            **{'url': 'http://yola.com', 'user_id': cls.user['id']})
+
+    def test_create_site_import(self):
+        self.assertTrue(self.site_import)
+
+    def test_get_site_import(self):
+        self.assertEqual(
+            self.service.get_site_import(self.site_import['id']),
+            self.site_import)
+
+    def test_get_user_site_imports(self):
+        self.assertEqual(
+            self.service.list_site_imports(user_id=self.user['id'])['results'],
+            [self.site_import])

--- a/yolapy/models/__init__.py
+++ b/yolapy/models/__init__.py
@@ -1,4 +1,5 @@
 from yolapy.models.user import User  # noqa
 from yolapy.models.partner import Partner  # noqa
 from yolapy.models.site import Site  # noqa
+from yolapy.models.siteimport import SiteImport  # noqa
 from yolapy.models.subscription import Subscription  # noqa

--- a/yolapy/models/siteimport.py
+++ b/yolapy/models/siteimport.py
@@ -1,0 +1,24 @@
+from demands.pagination import PaginatedResults
+from six import iteritems
+
+from yolapy.services import Yola
+
+
+class SiteImport(object):
+    def __init__(self, **kwargs):
+        for key, val in iteritems(kwargs):
+            setattr(self, key, val)
+
+    @classmethod
+    def create(cls, url, user_id):
+        return cls(**Yola().create_site_import(url, user_id))
+
+    @classmethod
+    def get(cls, id):
+        return cls(**Yola().get_site_import(id))
+
+    @classmethod
+    def list(cls, **filters):
+        site_imports = PaginatedResults(
+            Yola().list_site_imports, kwargs=filters)
+        return [cls(**site_import) for site_import in site_imports]

--- a/yolapy/models/siteimport.py
+++ b/yolapy/models/siteimport.py
@@ -5,20 +5,25 @@ from yolapy.services import Yola
 
 
 class SiteImport(object):
+    """Represents a SiteImport resource from the Yola API"""
+
     def __init__(self, **kwargs):
         for key, val in iteritems(kwargs):
             setattr(self, key, val)
 
     @classmethod
     def create(cls, url, user_id):
+        """Create a SiteImport with the Yola API"""
         return cls(**Yola().create_site_import(url, user_id))
 
     @classmethod
     def get(cls, id):
+        """Get a SiteImport from the Yola API"""
         return cls(**Yola().get_site_import(id))
 
     @classmethod
     def list(cls, **filters):
+        """Get a list of SiteImports from the Yola API"""
         site_imports = PaginatedResults(
             Yola().list_site_imports, kwargs=filters)
         return [cls(**site_import) for site_import in site_imports]

--- a/yolapy/resources/siteimport.py
+++ b/yolapy/resources/siteimport.py
@@ -1,0 +1,12 @@
+class SiteImportResourceMixin(object):
+    _path = '/pr/jobs/sites/'
+
+    def create_site_import(self, **data):
+        return self.post(
+            self._path, json=data).json()
+
+    def get_site_import(self, id):
+        return self.get('{url}{id}/'.format(url=self._path, id=id)).json()
+
+    def list_site_imports(self, **options):
+        return self.get(self._path, params=options).json()

--- a/yolapy/resources/siteimport.py
+++ b/yolapy/resources/siteimport.py
@@ -1,12 +1,17 @@
 class SiteImportResourceMixin(object):
+    """Yola API methods for SiteImports"""
+
     _path = '/pr/jobs/sites/'
 
     def create_site_import(self, **data):
+        """Create a SiteImport"""
         return self.post(
             self._path, json=data).json()
 
     def get_site_import(self, id):
+        """Return data for a specific SiteImport"""
         return self.get('{url}{id}/'.format(url=self._path, id=id)).json()
 
     def list_site_imports(self, **options):
+        """Return a paginated list of SiteImports"""
         return self.get(self._path, params=options).json()

--- a/yolapy/services.py
+++ b/yolapy/services.py
@@ -1,14 +1,14 @@
 from demands import HTTPServiceClient
 from yolapy.configuration import config as defaults
 from yolapy.resources import (
-    campaign, cname_zone, partner, site, subscription, user)
+    campaign, cname_zone, partner, site, siteimport, subscription, user)
 
 
 class Yola(
         HTTPServiceClient, campaign.CampaignResourceMixin,
         cname_zone.CnameZoneMixin, partner.PartnerResourceMixin,
-        site.SiteResourceMixin, subscription.SubscriptionResourceMixin,
-        user.UserResourceMixin):
+        site.SiteResourceMixin, siteimport.SiteImportResourceMixin,
+        subscription.SubscriptionResourceMixin, user.UserResourceMixin):
     """Client for Yola's API.
 
     If using yolapy.configuration::


### PR DESCRIPTION
Exposes methods for getting, listing, and creation of site import jobs in importservice