### PR TITLE
update `User.__init__` to accept **kwargs rather than named arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@ DEV
 ------------------
 * Fix bug caused by improper call signature to `create_site_import` method on
   `Yola` service
+* Update `User.__init__` to accept **kwargs rather than named arguments. This
+  makes it consistent with other yolapy models and more flexible in case of
+  changes to data returned by the service.
 
 
 0.5.0

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -22,8 +22,8 @@ class TestUserClient(UserTestCase):
 
 class TestUserGet(UserTestCase):
     """User.get"""
-
-    def test_instantiates_user_with_attrs_from_service(self):
+    def setUp(self):
+        super(TestUserGet, self).setUp()
         self.client.get_user.return_value = {
             'id': '123',
             'name': 'Firstname',
@@ -34,21 +34,27 @@ class TestUserGet(UserTestCase):
             'deleted': '2016-02-01',
             'partner_id': 'PARTNER',
             'preferences': {'currency': 'USD'},
+            'preferred_greeting': 'hi',
         }
 
-        user = User.get('123')
+        self.user = User.get('123')
 
+    def test_instantiates_user_with_attrs_from_service(self):
         self.client.get_user.assert_called_once_with('123')
-        self.assertEqual(user.id, '123')
-        self.assertEqual(user.active, True)
-        self.assertEqual(user.deleted, '2016-02-01')
-        self.assertEqual(user.signup_date, '2016-01-01')
-        self.assertEqual(user.partner_id, 'PARTNER')
-        self.assertEqual(user.name, 'Firstname')
-        self.assertEqual(user.surname, 'Lastname')
-        self.assertEqual(user.email, 'email@example.com')
-        self.assertEqual(user.name, 'Firstname')
-        self.assertDictEqual(user.preferences, {'currency': 'USD'})
+        self.assertEqual(self.user.id, '123')
+        self.assertEqual(self.user.active, True)
+        self.assertEqual(self.user.deleted, '2016-02-01')
+        self.assertEqual(self.user.signup_date, '2016-01-01')
+        self.assertEqual(self.user.partner_id, 'PARTNER')
+        self.assertEqual(self.user.name, 'Firstname')
+        self.assertEqual(self.user.surname, 'Lastname')
+        self.assertEqual(self.user.email, 'email@example.com')
+        self.assertEqual(self.user.name, 'Firstname')
+        self.assertDictEqual(self.user.preferences, {'currency': 'USD'})
+
+    def test_undeclared_fields_are_not_added_as_an_attribute(self):
+        with self.assertRaises(AttributeError):
+            self.user.greeting
 
 
 class TestUserSave(UserTestCase):

--- a/yolapy/models/user.py
+++ b/yolapy/models/user.py
@@ -2,7 +2,6 @@ from yolapy.services import Yola
 
 
 class User(object):
-
     """Yola User - a service model that uses the yola client for persistence.
 
     Example use:
@@ -43,7 +42,6 @@ class User(object):
         :rtype: yolapy.users.models.User
 
         """
-
         self.client = Yola()
 
         for field_name in self._fields:

--- a/yolapy/models/user.py
+++ b/yolapy/models/user.py
@@ -20,9 +20,10 @@ class User(object):
     ```
     """
 
-    def __init__(self, active=False, deleted=None, email=None, id=None,
-                 name=None, partner_id=None, preferences=None,
-                 signup_date=None, surname=None):
+    _fields = ('active', 'deleted', 'email', 'id', 'name', 'partner_id',
+               'preferences', 'signup_date', 'surname')
+
+    def __init__(self, **kwargs):
         """Construct a Yola User.
 
         The data in a User instance does not persist until it has been saved.
@@ -42,17 +43,15 @@ class User(object):
         :rtype: yolapy.users.models.User
 
         """
+
         self.client = Yola()
 
-        self.partner_id = partner_id or self.client.username
-        self.active = active
-        self.deleted = deleted
-        self.email = email
-        self.id = id
-        self.name = name
-        self.preferences = preferences or {}
-        self.signup_date = signup_date
-        self.surname = surname
+        for field_name in self._fields:
+            setattr(self, field_name, kwargs.get(field_name))
+
+        self.partner_id = self.partner_id or self.client.username
+        self.active = self.active or False
+        self.preferences = self.preferences or {}
 
     @classmethod
     def get(cls, user_id):


### PR DESCRIPTION
Closes https://github.com/yola/yolapy/issues/73

This makes the User model consistent with other yolapy models and more flexible in case of
changes to data returned by the service.
